### PR TITLE
Calculate iframe absolute offset relative to viewport when determining target

### DIFF
--- a/src/DragDropTouch.js
+++ b/src/DragDropTouch.js
@@ -298,18 +298,14 @@ export default () => {
         // if target element is an iframe, try propagating event to child element
         if (el && el.nodeName === 'IFRAME') {
           try {
-            var iframeDocument = el.contentWindow.document;
-            // get iframe absolute offset
-            var iframeAbsoluteOffset = { x: 0, y: 0 };
-            do {
-              iframeAbsoluteOffset.x += el.offsetLeft || 0;
-              iframeAbsoluteOffset.y += el.offsetTop || 0;
-              el = el.offsetParent;
-            } while (el);
+            // get iframe absolute offset relative to viewport
+            var rect = el.getBoundingClientRect();
+            var iframeAbsoluteOffset = { x: rect.x, y: rect.y };
             // remove iframe absolute offset from touch position
             var x = pt.x - iframeAbsoluteOffset.x,
               y = pt.y - iframeAbsoluteOffset.y;
             // get element on that position from iframe document
+            var iframeDocument = el.contentWindow.document;
             el = iframeDocument.elementFromPoint(x, y);
           } catch (e) {
             // iframe origin don't allow access

--- a/src/DragDropTouch.js
+++ b/src/DragDropTouch.js
@@ -300,10 +300,9 @@ export default () => {
           try {
             // get iframe absolute offset relative to viewport
             var rect = el.getBoundingClientRect();
-            var iframeAbsoluteOffset = { x: rect.x, y: rect.y };
             // remove iframe absolute offset from touch position
-            var x = pt.x - iframeAbsoluteOffset.x,
-              y = pt.y - iframeAbsoluteOffset.y;
+            var x = pt.x - rect.x,
+              y = pt.y - rect.y;
             // get element on that position from iframe document
             var iframeDocument = el.contentWindow.document;
             el = iframeDocument.elementFromPoint(x, y);


### PR DESCRIPTION
While trying to add the editor to a webpage where it would be located somewhere other than the document origin, I began to encounter issues dragging blocks into the editor, where they seemingly would only register if I hovered my finger around the bottom of the screen. 

Some investigating demonstrated that this was because the _getTarget function attempts to use the iframe's absolute offset within the document when trying to determine which element within is being selected/focused. This offset is then subtracted from the coordinates of the touchpoint from the event. However, it appears that the event's coordinates are calculated in terms of an offset from viewport rather than an offset from the document origin.

After making this change, I no longer encountered issues with dragging blocks into the editor on my page.